### PR TITLE
Remove the limitation on email configuration

### DIFF
--- a/S1ExcelPlugIn/FormExecutiveSummary.cs
+++ b/S1ExcelPlugIn/FormExecutiveSummary.cs
@@ -302,8 +302,6 @@ namespace S1ExcelPlugIn
         {
             if (textBoxSMTPHost.Text == "" ||
                 textBoxSMTPPort.Text == "" ||
-                textBoxUsername.Text == "" ||
-                textBoxPassword.Text == "" ||
                 textBoxMailFrom.Text == "")
             {
                 MessageBox.Show("Email server information not configured", "Message", MessageBoxButtons.OK, MessageBoxIcon.Information);


### PR DESCRIPTION
By default the plugin needs a username and password to be able to send an email. removing this limitation